### PR TITLE
fix: ideal height is 800

### DIFF
--- a/RedditOs/RedditOsApp.swift
+++ b/RedditOs/RedditOsApp.swift
@@ -32,7 +32,7 @@ struct RedditOsApp: App {
                            maxWidth: .infinity,
                            maxHeight: .infinity)
             }
-            .frame(minHeight: 400)
+            .frame(minHeight: 400, idealHeight: 800)
             .environmentObject(PersistedContent())
             .environmentObject(OauthClient.shared)
             .environmentObject(CurrentUser())


### PR DESCRIPTION
This is so the window isn't super tiny when first opening it. I think most modern Mac systems probably have a good enough screen resolution to default to 800.