### PR TITLE
Update layout of Post Row

### DIFF
--- a/RedditOs/Features/Subreddit/SubredditPostRow.swift
+++ b/RedditOs/Features/Subreddit/SubredditPostRow.swift
@@ -18,6 +18,13 @@ struct SubredditPostRow: View {
             case .large: return "list.bullet.below.rectangle"
             }
         }
+        
+        func numberOfLines() -> Int?  {
+            switch self {
+            case .compact: return 3
+            default: return nil
+            }
+        }
     }
     
     @StateObject var viewModel: PostViewModel
@@ -34,7 +41,7 @@ struct SubredditPostRow: View {
         NavigationLink(destination: PostDetailView(viewModel: viewModel)) {
             HStack {
                 VStack(alignment: .leading) {
-                    HStack(alignment: .top, spacing: 8) {
+                    HStack(alignment: .center, spacing: 8) {
                         PostVoteView(viewModel: viewModel)
                         if displayMode == .large {
                             SubredditPostThumbnailView(viewModel: viewModel)
@@ -44,7 +51,7 @@ struct SubredditPostRow: View {
                             Text(viewModel.post.title)
                                 .fontWeight(.bold)
                                 .font(.body)
-                                .lineLimit(displayMode == .compact ? 2 : nil)
+                                .lineLimit(displayMode.numberOfLines())
                                 .foregroundColor(viewModel.post.visited ? .gray : nil)
                             HStack {
                                 if let richText = viewModel.post.linkFlairRichtext, !richText.isEmpty {
@@ -94,6 +101,7 @@ struct SubredditPostRow: View {
                 
             } label: { Text("Copy URL") }
         }
+        Divider()
     }
 }
 

--- a/RedditOs/Features/Subreddit/SubredditPostRow.swift
+++ b/RedditOs/Features/Subreddit/SubredditPostRow.swift
@@ -53,6 +53,7 @@ struct SubredditPostRow: View {
                                 .font(.body)
                                 .lineLimit(displayMode.numberOfLines())
                                 .foregroundColor(viewModel.post.visited ? .gray : nil)
+                                .help(viewModel.post.title)
                             HStack {
                                 if let richText = viewModel.post.linkFlairRichtext, !richText.isEmpty {
                                     FlairView(richText: richText,

--- a/RedditOs/Features/Subreddit/SubredditPostThumbnailView.swift
+++ b/RedditOs/Features/Subreddit/SubredditPostThumbnailView.swift
@@ -50,7 +50,7 @@ struct SubredditPostThumbnailView: View {
                     .transition(.move(edge: .top))
                     .animation(.interactiveSpring())
             }
-        }
+        }.padding(4)
     }
 }
 

--- a/RedditOs/Shared/PostVoteView.swift
+++ b/RedditOs/Shared/PostVoteView.swift
@@ -37,7 +37,9 @@ struct PostVoteView: View {
                     .frame(width: 16, height: 16)
                     .foregroundColor(viewModel.post.likes == false ? .redditBlue : nil)
             }).buttonStyle(BorderlessButtonStyle())
-        }.frame(width: 40)
+        }
+        .frame(width: 40)
+        .padding(4)
     }
 }
 


### PR DESCRIPTION
Hey! Thanks for approving my yesterday's PR. 🙏

Sending another one with small changes to post row. Hopefully nothing controversial. I can see it's a complex layout so just making a mind padding changes and the most change is to placement of image and upvote/downvote to be centred rather than at the top. 

I would also like to propose to limit number of rows shown for title to provide a most consistent layout for each post.

Number number of lines logic into the enum (which can in theory be tested now).

Added a divider to give a bit more separation to each post for potentially better readability.

Attached screenshot of change. 
  
<img width="490" alt="Screenshot 2021-01-02 at 16 31 40" src="https://user-images.githubusercontent.com/31965092/103461818-0a76a180-4d19-11eb-8a31-26dbfb5d2e65.png">
