### PR TITLE
Add tooltip to toolbar display mode and update settings layout

### DIFF
--- a/RedditOs/Features/Profile/SubmittedPostsListView.swift
+++ b/RedditOs/Features/Profile/SubmittedPostsListView.swift
@@ -10,7 +10,7 @@ import Backend
 
 struct SubmittedPostsListView: View {
     @EnvironmentObject private var currentUser: CurrentUserStore
-    @State private var displayMode = SubredditPostRow.DisplayMode.large
+    @State private var displayMode: SubredditPostRow.DisplayMode = .large
     
     var body: some View {
         NavigationView {

--- a/RedditOs/Features/Settings/SettingsView.swift
+++ b/RedditOs/Features/Settings/SettingsView.swift
@@ -8,8 +8,8 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @AppStorage(SettingsKey.subreddit_display_mode) private var displayMode = SubredditPostRow.DisplayMode.large
-    @AppStorage(SettingsKey.subreddit_defaut_sort_order) private var sortOrder = SubredditViewModel.SortOrder.hot
+    @AppStorage(SettingsKey.subreddit_display_mode) private var displayMode: SubredditPostRow.DisplayMode = .large
+    @AppStorage(SettingsKey.subreddit_defaut_sort_order) private var sortOrder: SubredditViewModel.SortOrder = .hot
     
     var body: some View {
         TabView {
@@ -46,25 +46,28 @@ struct SettingsView: View {
     }
     
     private var generalView: some View {
-        Form {
-            Section(header: Text("Subreddit settings")) {
-                Picker("Display mode",
-                       selection: $displayMode,
-                       content: {
+        VStack {
+            Form {
+                Section(header: Text("Default Subreddit settings")) {
+                    
+                    Picker("Display layout style", selection: $displayMode) {
                         ForEach(SubredditPostRow.DisplayMode.allCases, id: \.self) { mode in
-                            Label(mode.rawValue, systemImage: mode.iconName()).tag(mode)
+                            Label(mode.rawValue, systemImage: mode.symbol()).tag(mode)
                         }
-                       })
-                
-                Picker(selection: $sortOrder,
-                       label: Text("Default sort"),
-                       content: {
+                    }
+                    
+                    Picker(selection: $sortOrder, label: Text("Sort order")) {
                         ForEach(SubredditViewModel.SortOrder.allCases, id: \.self) { sort in
                             Text(sort.rawValue.capitalized).tag(sort)
                         }
-                       })
+                    }
+                    
+                }
             }
-        }.frame(width: 500)
+            Spacer()
+        }
+        .frame(width: 500)
+        .padding()
     }
 }
 

--- a/RedditOs/Features/Subreddit/SubredditPostRow.swift
+++ b/RedditOs/Features/Subreddit/SubredditPostRow.swift
@@ -9,10 +9,12 @@ import SwiftUI
 import Backend
 
 struct SubredditPostRow: View {
+    
     enum DisplayMode: String, CaseIterable {
-        case compact, large
+        case compact = "Compact layout"
+        case large = "Full detail layout"
         
-        func iconName() -> String {
+        func symbol() -> String {
             switch self {
             case .compact: return "list.bullet"
             case .large: return "list.bullet.below.rectangle"

--- a/RedditOs/Features/Subreddit/SubredditPostsListView.swift
+++ b/RedditOs/Features/Subreddit/SubredditPostsListView.swift
@@ -48,7 +48,8 @@ struct SubredditPostsListView: View {
             PostsListView(posts: viewModel.listings,
                           displayMode: .constant(displayMode)) {
                 viewModel.fetchListings()
-            }.toolbar {
+            }
+            .toolbar {
                 ToolbarItem(placement: .navigation) {
                     Group {
                         if isDefaultChannel {
@@ -72,14 +73,14 @@ struct SubredditPostsListView: View {
                 }
                 
                 ToolbarItem {
-                    Picker("",
-                           selection: $displayMode,
-                           content: {
-                            ForEach(SubredditPostRow.DisplayMode.allCases, id: \.self) { mode in
-                                Image(systemName: mode.iconName())
-                                    .tag(mode)
-                            }
-                           }).pickerStyle(InlinePickerStyle())
+                    Picker("Display layout", selection: $displayMode) {
+                        ForEach(SubredditPostRow.DisplayMode.allCases, id: \.self) { item in
+                            Image(systemName: item.symbol())
+                                .tag(item)
+                        }
+                    }
+                    .pickerStyle(InlinePickerStyle())
+                    .help("Select display layout style")
                 }
                 
                 ToolbarItem {


### PR DESCRIPTION
Couple of small changes

1. Tooltip
<img width="252" alt="Screenshot 2021-01-04 at 22 56 14" src="https://user-images.githubusercontent.com/31965092/103592088-fa61ec00-4ee9-11eb-9851-d11c42f8346e.png">

2. Settings layout. Making it a bit more Mac like with setting aligned to top.
<img width="1034" alt="Screenshot 2021-01-05 at 00 05 27" src="https://user-images.githubusercontent.com/31965092/103592112-0c438f00-4eea-11eb-89d7-2338c391f20e.png">

Might need better naming for sections. 