### PR TITLE
Removed minimumScaleFactor from commentVoteView, to avoid scaling to unreadable sizes

### DIFF
--- a/RedditOs/Features/Comments/CommentVoteView.swift
+++ b/RedditOs/Features/Comments/CommentVoteView.swift
@@ -25,8 +25,6 @@ struct CommentVoteView: View {
             
             Text(viewModel.comment.score?.toRoundedSuffixAsString() ?? "Vote")
                 .font(.callout)
-                .fontWeight(.bold)
-                .minimumScaleFactor(0.1)
                 .lineLimit(1)
             
             Button(action: {


### PR DESCRIPTION
I don't really see a reason for the scaling, after comment votes reach 1000, they get abbreviated to 1k anyway. The text scales when it shouldn't, resulting small text even for 2 digit numbers. 

Before:
<img width="90" alt="Hot-Curiosity 2021-08-02 at 09 53 52" src="https://user-images.githubusercontent.com/61944932/127872826-32168ec2-cfcc-4049-968c-c4fe44a7e926.png">

After:
<img width="82" alt="Hot-Curiosity 2021-08-02 at 09 54 20" src="https://user-images.githubusercontent.com/61944932/127872895-54941c7a-a3ae-4828-b341-32527491b678.png">
