### PR TITLE
#62: Remove Active setting on Search tab

### DIFF
--- a/RedditOs/Environements/UIState.swift
+++ b/RedditOs/Environements/UIState.swift
@@ -44,10 +44,6 @@ class UIState: ObservableObject {
         }
     }
     
-    lazy var isSearchActive: Binding<Bool> = .init(get: {
-        self.sidebarSelection == Constants.searchTag
-    }, set: { _ in })
-    
     @Published var sidebarSelection: String? = DefaultChannels.hot.rawValue {
         didSet {
             if sidebarSelection != Constants.searchTag {

--- a/RedditOs/Features/Sidebar/SidebarView.swift
+++ b/RedditOs/Features/Sidebar/SidebarView.swift
@@ -88,7 +88,6 @@ struct SidebarView: View {
     private var mainSection: some View {
         Section(header: Text(SidebarItem.home.title())) {
             NavigationLink(destination: QuickSearchFullResultsView(),
-                           isActive: uiState.isSearchActive,
                            label: {
                             Label("Search", systemImage: "magnifyingglass")
                            })


### PR DESCRIPTION
Disclaimer: I am newer to iOS development and want to contribute to open source projects to learn so please all constructive criticism is welcome! 

I noticed that the `isActive` setting on the mainSection was the culprit of clearing out the selection on the third click. I could be mistaken but did not see anything else that would cause the issue. Remove these lines fixes the issue.  